### PR TITLE
[deps] upgrade visx-xychart to react 17

### DIFF
--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^16.4.0-0",
+    "react": "^17.0.0",
     "react-spring": "^9.2.0"
   },
   "dependencies": {

--- a/packages/visx-xychart/package.json
+++ b/packages/visx-xychart/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
+    "react": "^16.8.0 || ^17.0.0",
     "react-spring": "^9.2.0"
   },
   "dependencies": {

--- a/packages/visx-xychart/test/components/Annotation.test.tsx
+++ b/packages/visx-xychart/test/components/Annotation.test.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import {
-  Annotation as VxAnnotation,
-  EditableAnnotation as VxEditableAnnotation,
-} from '@visx/annotation';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { DataContext, Annotation, AnimatedAnnotation } from '../../src';
 import getDataContext from '../mocks/getDataContext';
 
 const series = { key: 'visx', data: [{}], xAccessor: () => 4, yAccessor: () => 7 };
 
 function setup(children: React.ReactNode) {
-  return mount(
+  return render(
     <DataContext.Provider value={getDataContext(series)}>
       <svg>{children}</svg>
     </DataContext.Provider>,
@@ -22,20 +19,22 @@ describe('<Annotation />', () => {
     expect(Annotation).toBeDefined();
   });
   it('should render a VxAnnotation', () => {
-    const wrapper = setup(
+    const { getByText } = setup(
       <Annotation dataKey={series.key} datum={{}}>
         {'test'}
       </Annotation>,
     );
-    expect(wrapper.find(VxAnnotation)).toHaveLength(1);
+    expect(getByText('test')).toBeInTheDocument();
   });
   it('should render a VxEditableAnnotation when editable=true', () => {
-    const wrapper = setup(
+    const { container } = setup(
       <Annotation editable dataKey={series.key} datum={{}}>
         {'test'}
       </Annotation>,
     );
-    expect(wrapper.find(VxEditableAnnotation)).toHaveLength(1);
+    // with editable=true, the svg should have a circle overlay with 'cursor: grab' attribute
+    const CircleElement = container.querySelector('circle');
+    expect(CircleElement).toHaveAttribute('cursor');
   });
 });
 
@@ -44,19 +43,22 @@ describe('<AnimatedAnnotation />', () => {
     expect(AnimatedAnnotation).toBeDefined();
   });
   it('should render a VxAnnotation', () => {
-    const wrapper = setup(
+    const { getByText } = setup(
       <AnimatedAnnotation dataKey={series.key} datum={{}}>
         {'test'}
       </AnimatedAnnotation>,
     );
-    expect(wrapper.find(VxAnnotation)).toHaveLength(1);
+    expect(getByText('test')).toBeInTheDocument();
   });
   it('should render a VxEditableAnnotation when editable=true', () => {
-    const wrapper = setup(
+    const { container } = setup(
       <AnimatedAnnotation editable dataKey={series.key} datum={{}}>
         {'test'}
       </AnimatedAnnotation>,
     );
-    expect(wrapper.find(VxEditableAnnotation)).toHaveLength(1);
+
+    // with editable=true, the svg should have a circle overlay with 'cursor: grab' attribute
+    const CircleElement = container.querySelector('circle');
+    expect(CircleElement).toHaveAttribute('cursor');
   });
 });

--- a/packages/visx-xychart/test/components/AreaSeries.test.tsx
+++ b/packages/visx-xychart/test/components/AreaSeries.test.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect } from 'react';
-import { animated } from 'react-spring';
-import { mount } from 'enzyme';
-import { Area, LinePath } from '@visx/shape';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { AnimatedAreaSeries, DataContext, AreaSeries, useEventEmitter } from '../../src';
 import getDataContext from '../mocks/getDataContext';
 import setupTooltipTest from '../mocks/setupTooltipTest';
@@ -15,31 +14,33 @@ describe('<AreaSeries />', () => {
   });
 
   it('should render an Area', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <AreaSeries dataKey={series.key} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    // @ts-ignore produces a union type that is too complex to represent.ts(2590)
-    expect(wrapper.find(Area)).toHaveLength(1);
+    const Path = container.querySelector('path');
+    expect(Path).toBeInTheDocument();
   });
 
   it('should set strokeLinecap="round" to make datum surrounded by nulls visible', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <AreaSeries dataKey={series.key} renderLine={false} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find('path').prop('strokeLinecap')).toBe('round');
+    const Path = container.querySelector('path');
+    expect(Path).toBeInTheDocument();
+    expect(Path).toHaveAttribute('stroke-linecap', 'round');
   });
 
-  it('should use x/y0Accessors an Area', () => {
+  it('should use x/y0Accessors in an Area', () => {
     const y0Accessor = jest.fn(() => 3);
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <AreaSeries dataKey={series.key} {...series} y0Accessor={y0Accessor} />
@@ -47,34 +48,35 @@ describe('<AreaSeries />', () => {
       </DataContext.Provider>,
     );
 
-    const callCount = y0Accessor.mock.calls.length;
+    const Path = container.querySelector('path');
+    expect(Path).toBeInTheDocument();
     expect(y0Accessor).toHaveBeenCalled();
-    const y0Area = wrapper.find(Area).prop('y0') as Function;
-    y0Area();
-    expect(y0Accessor).toHaveBeenCalledTimes(callCount + 1);
   });
 
   it('should render a LinePath is renderLine=true', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <AreaSeries renderLine dataKey={series.key} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    // @ts-ignore produces a union type that is too complex to represent.ts(2590)
-    expect(wrapper.find(LinePath)).toHaveLength(1);
+
+    const LinePath = container.querySelector('.visx-line');
+    expect(LinePath).toBeInTheDocument();
   });
 
   it('should render Glyphs if focus/blur handlers are set', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <AreaSeries dataKey={series.key} {...series} onFocus={() => {}} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find('circle')).toHaveLength(series.data.length);
+
+    const Circles = container.querySelectorAll('circle');
+    expect(Circles).toHaveLength(series.data.length);
   });
 
   it('should invoke showTooltip/hideTooltip on pointermove/pointerout', () => {
@@ -123,13 +125,14 @@ describe('<AnimatedAreaSeries />', () => {
     expect(AnimatedAreaSeries).toBeDefined();
   });
   it('should render an animated.path', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <AnimatedAreaSeries renderLine={false} dataKey={series.key} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find(animated.path)).toHaveLength(1);
+    const Path = container.querySelectorAll('path');
+    expect(Path).toHaveLength(1);
   });
 });

--- a/packages/visx-xychart/test/components/AreaStack.test.tsx
+++ b/packages/visx-xychart/test/components/AreaStack.test.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect } from 'react';
-import { mount } from 'enzyme';
-import { animated } from 'react-spring';
-import { Area, LinePath } from '@visx/shape';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import {
   AreaStack,
   AreaSeries,
@@ -48,7 +47,7 @@ describe('<AreaStack />', () => {
   });
 
   it('should render Areas', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <AreaStack>
@@ -58,12 +57,12 @@ describe('<AreaStack />', () => {
         </svg>
       </DataProvider>,
     );
-    // @ts-ignore produces a union type that is too complex to represent.ts(2590)
-    expect(wrapper.find(Area)).toHaveLength(2);
+    const Areas = container.querySelectorAll('.visx-area');
+    expect(Areas).toHaveLength(2);
   });
 
   it('should render LinePaths if renderLine=true', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <AreaStack renderLine>
@@ -73,12 +72,12 @@ describe('<AreaStack />', () => {
         </svg>
       </DataProvider>,
     );
-    // @ts-ignore produces a union type that is too complex to represent.ts(2590)
-    expect(wrapper.find(LinePath)).toHaveLength(2);
+    const LinePaths = container.querySelectorAll('.visx-line');
+    expect(LinePaths).toHaveLength(2);
   });
 
   it('should render Glyphs if focus/blur handlers are set', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <AreaStack onFocus={() => {}}>
@@ -87,7 +86,8 @@ describe('<AreaStack />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find('circle')).toHaveLength(series1.data.length);
+    const Circles = container.querySelectorAll('circle');
+    expect(Circles).toHaveLength(series1.data.length);
   });
 
   it('should update scale domain to include stack sums including negative values', () => {
@@ -101,7 +101,7 @@ describe('<AreaStack />', () => {
       return null;
     }
 
-    mount(
+    render(
       <DataProvider {...providerProps}>
         <svg>
           <AreaStack>
@@ -165,7 +165,7 @@ describe('<AnimatedAreaStack />', () => {
     expect(AnimatedAreaStack).toBeDefined();
   });
   it('should render an animated.path', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <AnimatedAreaStack renderLine={false}>
@@ -175,6 +175,7 @@ describe('<AnimatedAreaStack />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find(animated.path)).toHaveLength(2);
+    const Circles = container.querySelectorAll('path');
+    expect(Circles).toHaveLength(2);
   });
 });

--- a/packages/visx-xychart/test/components/Axis.test.tsx
+++ b/packages/visx-xychart/test/components/Axis.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { scaleLinear } from '@visx/scale';
 import BaseAxis from '../../src/components/axis/BaseAxis';
 import { Axis, AnimatedAxis, DataContext, lightTheme } from '../../src';
 import getDataContext from '../mocks/getDataContext';
@@ -50,6 +51,32 @@ describe('<BaseAxis />', () => {
     );
     const AxisComponents = container.querySelectorAll('.visx-axis');
     expect(AxisComponents).toHaveLength(1);
+  });
+
+  it('should use scale=xScale for orientation=top (or bottom)', () => {
+    const xScale = scaleLinear({ domain: [0, 4], range: [0, 10] });
+    const { container } = setup(
+      <BaseAxis orientation="top" AxisComponent={() => <Axis orientation="top" />} />,
+      { xScale },
+    );
+    const TickLabels = container.querySelectorAll('tspan');
+    expect(TickLabels[0].textContent).toEqual('0.0');
+    expect(TickLabels[0]).toHaveAttribute('x', '0');
+    expect(TickLabels[TickLabels.length - 1].textContent).toEqual('4.0');
+    expect(TickLabels[TickLabels.length - 1]).toHaveAttribute('x', '10');
+  });
+
+  it('should use scale=yScale for orientation=left (or right)', () => {
+    const yScale = scaleLinear({ domain: [0, 4], range: [0, 10] });
+    const { container } = setup(
+      <BaseAxis orientation="left" AxisComponent={() => <Axis orientation="left" />} />,
+      { yScale },
+    );
+    const TickLabels = container.querySelectorAll('tspan');
+    expect(TickLabels[0].textContent).toEqual('0.0');
+    expect(TickLabels[0].parentNode).toHaveAttribute('y', '0');
+    expect(TickLabels[TickLabels.length - 1].textContent).toEqual('4.0');
+    expect(TickLabels[TickLabels.length - 1].parentNode).toHaveAttribute('y', '10');
   });
 
   it('should use axis styles from context theme unless specified in props', () => {

--- a/packages/visx-xychart/test/components/Axis.test.tsx
+++ b/packages/visx-xychart/test/components/Axis.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import VxAnimatedAxis from '@visx/react-spring/lib/axis/AnimatedAxis';
-import VxAxis from '@visx/axis/lib/axis/Axis';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import BaseAxis from '../../src/components/axis/BaseAxis';
 import { Axis, AnimatedAxis, DataContext, lightTheme } from '../../src';
 import getDataContext from '../mocks/getDataContext';
@@ -12,7 +11,7 @@ function setup(
   children: React.ReactNode,
   contextOverrides?: Partial<ReturnType<typeof getDataContext>>,
 ) {
-  return mount(
+  return render(
     <DataContext.Provider value={{ ...getDataContext(series), ...contextOverrides }}>
       <svg>{children}</svg>
     </DataContext.Provider>,
@@ -24,7 +23,9 @@ describe('<Axis />', () => {
     expect(Axis).toBeDefined();
   });
   it('should render a VxAxis', () => {
-    expect(setup(<Axis orientation="bottom" />).find(VxAxis)).toHaveLength(1);
+    expect(
+      setup(<Axis orientation="bottom" />).container.querySelectorAll('.visx-axis'),
+    ).toHaveLength(1);
   });
 });
 
@@ -33,70 +34,44 @@ describe('<AnimatedAxis />', () => {
     expect(AnimatedAxis).toBeDefined();
   });
   it('should render a VxAnimatedAxis', () => {
-    expect(setup(<AnimatedAxis orientation="bottom" />).find(VxAnimatedAxis)).toHaveLength(1);
+    expect(
+      setup(<AnimatedAxis orientation="bottom" />).container.querySelectorAll('.visx-axis'),
+    ).toHaveLength(1);
   });
 });
-
-const AxisComponent = (_: unknown) => null;
 
 describe('<BaseAxis />', () => {
   it('should be defined', () => {
     expect(BaseAxis).toBeDefined();
   });
-  it('should use scale=xScale for orientation=top/bottom', () => {
-    const xScale = jest.fn();
-    const axes = setup(
-      <>
-        <BaseAxis orientation="top" AxisComponent={AxisComponent} />
-        <BaseAxis orientation="bottom" AxisComponent={AxisComponent} />
-      </>,
-      { xScale },
-    ).find(AxisComponent);
-    expect(axes.at(0).prop('scale')).toBe(xScale);
-    expect(axes.at(1).prop('scale')).toBe(xScale);
+  it('<BaseAxis/> renders', () => {
+    const { container } = setup(
+      <BaseAxis orientation="top" AxisComponent={() => <Axis orientation="top" />} />,
+    );
+    const AxisComponents = container.querySelectorAll('.visx-axis');
+    expect(AxisComponents).toHaveLength(1);
   });
-  it('should use scale=yScale for orientation=left/right', () => {
-    const yScale = jest.fn();
-    const axes = setup(
-      <>
-        <BaseAxis orientation="left" AxisComponent={AxisComponent} />
-        <BaseAxis orientation="right" AxisComponent={AxisComponent} />
-      </>,
-      { yScale },
-    ).find(AxisComponent);
-    expect(axes.at(0).prop('scale')).toBe(yScale);
-    expect(axes.at(1).prop('scale')).toBe(yScale);
-  });
+
   it('should use axis styles from context theme unless specified in props', () => {
     const axisStyles = lightTheme.axisStyles.x.top;
-    const axis = setup(
+    const { container } = setup(
       <BaseAxis
-        orientation="top"
-        AxisComponent={AxisComponent}
-        stroke="violet"
-        tickLength={12345}
+        orientation="left"
+        AxisComponent={() => <Axis orientation="top" stroke="#22222" tickLength={12345} />}
       />,
-    ).find(AxisComponent);
-    expect(axis.prop('labelProps')).toBe(axisStyles.axisLabel);
-    expect(axis.prop('stroke')).toBe('violet');
-    expect(axis.prop('strokeWidth')).toBe(axisStyles.axisLine.strokeWidth);
-    expect(axis.prop('tickLength')).toBe(12345);
-    expect(axis.prop('tickStroke')).toBe(axisStyles.tickLine.stroke);
-  });
-  it('should use props.tickLabelProps if passed', () => {
-    const tickLabelProps = jest.fn(() => ({ fill: 'visx' }));
-    const axis = setup(
-      <BaseAxis orientation="left" AxisComponent={AxisComponent} tickLabelProps={tickLabelProps} />,
-    ).find(AxisComponent);
-    const tickLabelPropsFn = axis.prop('tickLabelProps') as Function;
-    expect(tickLabelPropsFn()).toMatchObject({ fill: 'visx' });
-  });
-  it('should construct tickLabelProps from theme if props.tickLabelProps is not passed', () => {
-    const tickStyles = lightTheme.axisStyles.y.left.tickLabel;
-    const axis = setup(<BaseAxis orientation="left" AxisComponent={AxisComponent} />).find(
-      AxisComponent,
     );
-    const tickLabelProps = axis.prop('tickLabelProps') as Function;
-    expect(tickLabelProps()).toMatchObject(tickStyles);
+
+    const VisxAxisLine = container.querySelector('.visx-axis-line');
+    const VisxLine = container.querySelector('.visx-line');
+
+    // specified styles in the props
+    expect(VisxAxisLine).toHaveAttribute('stroke', '#22222');
+    // tick length = y1-y2 of axis line
+    expect(VisxLine).toHaveAttribute('y1', '0');
+    expect(VisxLine).toHaveAttribute('y2', '-12345');
+
+    // context theme styles
+    expect(VisxLine).toHaveAttribute('stroke-width', `${axisStyles.axisLine.strokeWidth}`);
+    expect(VisxLine).toHaveAttribute('stroke', axisStyles.tickLine.stroke);
   });
 });

--- a/packages/visx-xychart/test/components/BarGroup.test.tsx
+++ b/packages/visx-xychart/test/components/BarGroup.test.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
-import { animated } from 'react-spring';
-import { mount } from 'enzyme';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
 import {
   AnimatedBarGroup,
   BarGroup,
@@ -53,7 +53,7 @@ describe('<BarGroup />', () => {
   });
 
   it('should render rects', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <BarGroup>
@@ -63,11 +63,11 @@ describe('<BarGroup />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find('rect')).toHaveLength(4);
+    expect(container.querySelectorAll('rect')).toHaveLength(4);
   });
 
   it('should use colorAccessor if passed', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <BarGroup>
@@ -81,15 +81,15 @@ describe('<BarGroup />', () => {
         </svg>
       </DataProvider>,
     );
-    const rects = wrapper.find('rect');
-    expect(rects.at(0).prop('fill')).not.toBe('banana');
-    expect(rects.at(1).prop('fill')).not.toBe('banana');
-    expect(rects.at(2).prop('fill')).toBe('banana');
-    expect(rects.at(3).prop('fill')).not.toBe('banana');
+    const rects = container.querySelectorAll('rect');
+    expect(rects[0]).not.toHaveAttribute('fill', 'banana');
+    expect(rects[1]).not.toHaveAttribute('fill', 'banana');
+    expect(rects[2]).toHaveAttribute('fill', 'banana');
+    expect(rects[3]).not.toHaveAttribute('fill', 'banana');
   });
 
   it('should not render rects with invalid x or y', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <BarGroup>
@@ -99,7 +99,7 @@ describe('<BarGroup />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find('rect')).toHaveLength(3);
+    expect(container.querySelectorAll('rect')).toHaveLength(3);
   });
 
   it('should invoke showTooltip/hideTooltip on pointermove/pointerout', () => {
@@ -146,7 +146,7 @@ describe('<AnimatedBarGroup />', () => {
     expect(AnimatedBarGroup).toBeDefined();
   });
   it('should render an animated.rect', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <AnimatedBarGroup>
@@ -156,6 +156,6 @@ describe('<AnimatedBarGroup />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find(animated.rect)).toHaveLength(4);
+    expect(container.querySelectorAll('rect')).toHaveLength(4);
   });
 });

--- a/packages/visx-xychart/test/components/BarSeries.test.tsx
+++ b/packages/visx-xychart/test/components/BarSeries.test.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
-import { animated } from 'react-spring';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { DataContext, AnimatedBarSeries, BarSeries, useEventEmitter } from '../../src';
 import getDataContext from '../mocks/getDataContext';
 import setupTooltipTest from '../mocks/setupTooltipTest';
@@ -20,18 +20,18 @@ describe('<BarSeries />', () => {
   });
 
   it('should render rects', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <BarSeries dataKey={series.key} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find('rect')).toHaveLength(2);
+    expect(container.querySelectorAll('rect')).toHaveLength(2);
   });
 
   it('should use colorAccessor if passed', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <BarSeries
@@ -42,20 +42,20 @@ describe('<BarSeries />', () => {
         </svg>
       </DataContext.Provider>,
     );
-    const rects = wrapper.find('rect');
-    expect(rects.at(0).prop('fill')).toBe('banana');
-    expect(rects.at(1).prop('fill')).not.toBe('banana');
+    const rects = container.querySelectorAll('rect');
+    expect(rects[0]).toHaveAttribute('fill', 'banana');
+    expect(rects[1]).not.toHaveAttribute('fill', 'banana');
   });
 
   it('should not render rects if x or y is invalid', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(seriesMissingData)}>
         <svg>
           <BarSeries dataKey={seriesMissingData.key} {...seriesMissingData} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find('rect')).toHaveLength(1);
+    expect(container.querySelectorAll('rect')).toHaveLength(1);
   });
 
   it('should invoke showTooltip/hideTooltip on pointermove/pointerout', () => {
@@ -104,13 +104,13 @@ describe('<AnimatedBarSeries />', () => {
     expect(AnimatedBarSeries).toBeDefined();
   });
   it('should render an animated.rect', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <AnimatedBarSeries dataKey={series.key} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find(animated.rect)).toHaveLength(series.data.length);
+    expect(container.querySelectorAll('rect')).toHaveLength(series.data.length);
   });
 });

--- a/packages/visx-xychart/test/components/BarStack.test.tsx
+++ b/packages/visx-xychart/test/components/BarStack.test.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
-import { mount } from 'enzyme';
-import { animated } from 'react-spring';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import {
   BarStack,
   BarSeries,
@@ -52,7 +52,7 @@ describe('<BarStack />', () => {
   });
 
   it('should render rects', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <BarStack>
@@ -62,11 +62,12 @@ describe('<BarStack />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find('rect')).toHaveLength(4);
+    const RectElements = container.querySelectorAll('rect');
+    expect(RectElements).toHaveLength(4);
   });
 
   it('should use colorAccessor if passed', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <BarStack>
@@ -80,15 +81,15 @@ describe('<BarStack />', () => {
         </svg>
       </DataProvider>,
     );
-    const rects = wrapper.find('rect');
-    expect(rects.at(0).prop('fill')).not.toBe('banana');
-    expect(rects.at(1).prop('fill')).not.toBe('banana');
-    expect(rects.at(2).prop('fill')).toBe('banana');
-    expect(rects.at(3).prop('fill')).not.toBe('banana');
+    const RectElements = container.querySelectorAll('rect');
+    expect(RectElements[0]).not.toHaveAttribute('fill', 'banana');
+    expect(RectElements[1]).not.toHaveAttribute('fill', 'banana');
+    expect(RectElements[2]).toHaveAttribute('fill', 'banana');
+    expect(RectElements[3]).not.toHaveAttribute('fill', 'banana');
   });
 
   it('should not render rects if x or y are invalid', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <BarStack>
@@ -98,7 +99,8 @@ describe('<BarStack />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find('rect')).toHaveLength(3);
+    const RectElements = container.querySelectorAll('rect');
+    expect(RectElements).toHaveLength(3);
   });
 
   it('should update scale domain to include stack sums including negative values', () => {
@@ -112,7 +114,7 @@ describe('<BarStack />', () => {
       return null;
     }
 
-    mount(
+    render(
       <DataProvider {...providerProps}>
         <svg>
           <BarStack>
@@ -176,7 +178,7 @@ describe('<AnimatedBarStack />', () => {
     expect(AnimatedBarStack).toBeDefined();
   });
   it('should render an animated.rect', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataProvider {...providerProps}>
         <svg>
           <AnimatedBarStack>
@@ -186,6 +188,7 @@ describe('<AnimatedBarStack />', () => {
         </svg>
       </DataProvider>,
     );
-    expect(wrapper.find(animated.rect)).toHaveLength(4);
+    const RectElements = container.querySelectorAll('rect');
+    expect(RectElements).toHaveLength(4);
   });
 });

--- a/packages/visx-xychart/test/components/GlyphSeries.test.tsx
+++ b/packages/visx-xychart/test/components/GlyphSeries.test.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
-import { animated } from 'react-spring';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { AnimatedGlyphSeries, DataContext, GlyphSeries, useEventEmitter } from '../../src';
 import getDataContext from '../mocks/getDataContext';
 import setupTooltipTest from '../mocks/setupTooltipTest';
@@ -20,18 +20,18 @@ describe('<GlyphSeries />', () => {
   });
 
   it('should render a DefaultGlyph for each Datum', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <GlyphSeries dataKey={series.key} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find('circle')).toHaveLength(series.data.length);
+    expect(container.querySelectorAll('circle')).toHaveLength(series.data.length);
   });
 
   it('should use colorAccessor if passed', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <GlyphSeries
@@ -42,32 +42,32 @@ describe('<GlyphSeries />', () => {
         </svg>
       </DataContext.Provider>,
     );
-    const circles = wrapper.find('circle');
-    expect(circles.at(0).prop('fill')).toBe('banana');
-    expect(circles.at(1).prop('fill')).not.toBe('banana');
+    const circles = container.querySelectorAll('circle');
+    expect(circles[0]).toHaveAttribute('fill', 'banana');
+    expect(circles[1]).not.toHaveAttribute('fill', 'banana');
   });
 
   it('should not render Glyphs if x or y is invalid', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(seriesMissingData)}>
         <svg>
           <GlyphSeries dataKey={seriesMissingData.key} {...seriesMissingData} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find('circle')).toHaveLength(1);
+    expect(container.querySelectorAll('circle')).toHaveLength(1);
   });
 
   it('should render a custom Glyph for each Datum', () => {
     const customRenderGlyph = () => <rect className="custom-glyph" />;
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <GlyphSeries dataKey={series.key} {...series} renderGlyph={customRenderGlyph} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find('.custom-glyph')).toHaveLength(series.data.length);
+    expect(container.querySelectorAll('.custom-glyph')).toHaveLength(series.data.length);
   });
 
   it('should invoke showTooltip/hideTooltip on pointermove/pointerout', () => {
@@ -116,13 +116,13 @@ describe('<AnimatedGlyphSeries />', () => {
     expect(AnimatedGlyphSeries).toBeDefined();
   });
   it('should render an animated.g for each datum', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <AnimatedGlyphSeries dataKey={series.key} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find(animated.g)).toHaveLength(series.data.length);
+    expect(container.querySelectorAll('g')).toHaveLength(series.data.length);
   });
 });

--- a/packages/visx-xychart/test/components/Grid.test.tsx
+++ b/packages/visx-xychart/test/components/Grid.test.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
-import VxAnimatedGridRows from '@visx/react-spring/lib/grid/AnimatedGridRows';
-import VxAnimatedGridColumns from '@visx/react-spring/lib/grid/AnimatedGridColumns';
-import VxGridRows from '@visx/grid/lib/grids/GridRows';
-import VxGridColumns from '@visx/grid/lib/grids/GridColumns';
+import { render } from '@testing-library/react';
 import { Grid, AnimatedGrid, DataContext } from '../../src';
 import getDataContext from '../mocks/getDataContext';
 
@@ -14,26 +10,26 @@ describe('<Grid />', () => {
     expect(Grid).toBeDefined();
   });
   it('should render VxGridRows if rows=true', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={mockContext}>
         <svg>
           <Grid rows columns={false} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find(VxGridRows)).toHaveLength(1);
-    expect(wrapper.find(VxGridColumns)).toHaveLength(0);
+    expect(container.querySelectorAll('.visx-rows')).toHaveLength(1);
+    expect(container.querySelectorAll('.visx-columns')).toHaveLength(0);
   });
   it('should render VxGridColumns if columns=true', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={mockContext}>
         <svg>
           <Grid rows={false} columns />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find(VxGridRows)).toHaveLength(0);
-    expect(wrapper.find(VxGridColumns)).toHaveLength(1);
+    expect(container.querySelectorAll('.visx-rows')).toHaveLength(0);
+    expect(container.querySelectorAll('.visx-columns')).toHaveLength(1);
   });
 });
 
@@ -42,25 +38,25 @@ describe('<AnimatedGrid />', () => {
     expect(AnimatedGrid).toBeDefined();
   });
   it('should render VxAnimatedGridRows if rows=true', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={mockContext}>
         <svg>
           <AnimatedGrid rows columns={false} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find(VxAnimatedGridRows)).toHaveLength(1);
-    expect(wrapper.find(VxAnimatedGridColumns)).toHaveLength(0);
+    expect(container.querySelectorAll('.visx-rows')).toHaveLength(1);
+    expect(container.querySelectorAll('.visx-columns')).toHaveLength(0);
   });
   it('should render VxAnimatedGridColumns if columns=true', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={mockContext}>
         <svg>
           <AnimatedGrid rows={false} columns />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find(VxAnimatedGridRows)).toHaveLength(0);
-    expect(wrapper.find(VxAnimatedGridColumns)).toHaveLength(1);
+    expect(container.querySelectorAll('.visx-rows')).toHaveLength(0);
+    expect(container.querySelectorAll('.visx-columns')).toHaveLength(1);
   });
 });

--- a/packages/visx-xychart/test/components/LineSeries.test.tsx
+++ b/packages/visx-xychart/test/components/LineSeries.test.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect } from 'react';
-import { animated } from 'react-spring';
-import { mount } from 'enzyme';
-import { LinePath } from '@visx/shape';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { AnimatedLineSeries, DataContext, LineSeries, useEventEmitter } from '../../src';
 import getDataContext from '../mocks/getDataContext';
 import setupTooltipTest from '../mocks/setupTooltipTest';
@@ -15,7 +14,7 @@ describe('<LineSeries />', () => {
   });
 
   it('should render a LinePath', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <LineSeries dataKey={series.key} {...series} />
@@ -23,29 +22,29 @@ describe('<LineSeries />', () => {
       </DataContext.Provider>,
     );
     // @ts-ignore produces a union type that is too complex to represent.ts(2590)
-    expect(wrapper.find(LinePath)).toHaveLength(1);
+    expect(container.querySelectorAll('path')).toHaveLength(1);
   });
 
   it('should set strokeLinecap="round" to make datum surrounded by nulls visible', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <LineSeries dataKey={series.key} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find('path').prop('strokeLinecap')).toBe('round');
+    expect(container.querySelector('path')).toHaveAttribute('stroke-linecap', 'round');
   });
 
   it('should render Glyphs if focus/blur handlers are set', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <LineSeries dataKey={series.key} {...series} onFocus={() => {}} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find('circle')).toHaveLength(series.data.length);
+    expect(container.querySelectorAll('circle')).toHaveLength(series.data.length);
   });
 
   it('should invoke showTooltip/hideTooltip on pointermove/pointerout', () => {
@@ -94,13 +93,13 @@ describe('<AnimatedLineSeries />', () => {
     expect(AnimatedLineSeries).toBeDefined();
   });
   it('should render an animated.path', () => {
-    const wrapper = mount(
+    const { container } = render(
       <DataContext.Provider value={getDataContext(series)}>
         <svg>
           <AnimatedLineSeries dataKey={series.key} {...series} />
         </svg>
       </DataContext.Provider>,
     );
-    expect(wrapper.find(animated.path)).toHaveLength(1);
+    expect(container.querySelectorAll('path')).toHaveLength(1);
   });
 });

--- a/packages/visx-xychart/test/components/LineSeries.test.tsx
+++ b/packages/visx-xychart/test/components/LineSeries.test.tsx
@@ -21,7 +21,6 @@ describe('<LineSeries />', () => {
         </svg>
       </DataContext.Provider>,
     );
-    // @ts-ignore produces a union type that is too complex to represent.ts(2590)
     expect(container.querySelectorAll('path')).toHaveLength(1);
   });
 

--- a/packages/visx-xychart/test/components/Tooltip.test.tsx
+++ b/packages/visx-xychart/test/components/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ResizeObserver from 'resize-observer-polyfill';
-import { mount } from 'enzyme';
-import { Tooltip as BaseTooltip } from '@visx/tooltip';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import {
   DataContext,
   DataRegistryEntry,
@@ -17,12 +17,14 @@ describe('<Tooltip />', () => {
     | {
         props?: Partial<TooltipProps<object>>;
         context?: Partial<TooltipContextType<object>>;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         dataEntries?: DataRegistryEntry<any, any, any>[];
       }
     | undefined;
 
   function setup({ props, context, dataEntries = [] }: SetupProps = {}) {
-    const wrapper = mount(
+    //  Disable Warning: render(): Rendering components directly into document.body is discouraged.
+    const wrapper = render(
       <DataContext.Provider
         value={{
           ...getDataContext(dataEntries),
@@ -52,21 +54,24 @@ describe('<Tooltip />', () => {
   });
 
   it('should not render a BaseTooltip when TooltipContext.tooltipOpen=false', () => {
-    const wrapper = setup();
-    expect(wrapper.find(BaseTooltip)).toHaveLength(0);
+    const { container } = setup();
+    expect(container?.parentNode?.querySelectorAll('.visx-tooltip')).toHaveLength(0);
   });
 
   it('should not render a BaseTooltip when TooltipContext.tooltipOpen=true and renderTooltip returns false', () => {
-    const wrapper = setup({ context: { tooltipOpen: true }, props: { renderTooltip: () => null } });
-    expect(wrapper.find(BaseTooltip)).toHaveLength(0);
+    const { container } = setup({
+      context: { tooltipOpen: true },
+      props: { renderTooltip: () => null },
+    });
+    expect(container?.parentNode?.querySelectorAll('.visx-tooltip')).toHaveLength(0);
   });
 
   it('should render a BaseTooltip when TooltipContext.tooltipOpen=true and renderTooltip returns non-null', () => {
-    const wrapper = setup({
+    const { container } = setup({
       props: { renderTooltip: () => <div />, snapTooltipToDatumX: true },
       context: { tooltipOpen: true },
     });
-    expect(wrapper.find(BaseTooltip)).toHaveLength(1);
+    expect(container?.parentNode?.querySelectorAll('.visx-tooltip')).toHaveLength(1);
   });
 
   it('should not invoke props.renderTooltip when TooltipContext.tooltipOpen=false', () => {
@@ -87,23 +92,25 @@ describe('<Tooltip />', () => {
   });
 
   it('should render a vertical crosshair if showVerticalCrossHair=true', () => {
-    const wrapper = setup({
+    const { container } = setup({
       props: { showVerticalCrosshair: true },
       context: { tooltipOpen: true },
     });
-    expect(wrapper.find('div.visx-crosshair-vertical')).toHaveLength(1);
+    expect(container?.parentNode?.querySelectorAll('div.visx-crosshair-vertical')).toHaveLength(1);
   });
 
   it('should render a horizontal crosshair if showVerticalCrossHair=true', () => {
-    const wrapper = setup({
+    const { container } = setup({
       props: { showHorizontalCrosshair: true },
       context: { tooltipOpen: true },
     });
-    expect(wrapper.find('div.visx-crosshair-horizontal')).toHaveLength(1);
+    expect(container?.parentNode?.querySelectorAll('div.visx-crosshair-horizontal')).toHaveLength(
+      1,
+    );
   });
 
   it('should not render a glyph if showDatumGlyph=true and there is no nearestDatum', () => {
-    const wrapper = setup({
+    const { container } = setup({
       props: { showDatumGlyph: true },
       context: {
         tooltipOpen: true,
@@ -120,10 +127,11 @@ describe('<Tooltip />', () => {
         },
       ],
     });
-    expect(wrapper.find('div.visx-tooltip-glyph')).toHaveLength(0);
+    expect(container?.parentNode?.querySelectorAll('div.visx-tooltip-glyph')).toHaveLength(0);
   });
+
   it('should render a glyph if showDatumGlyph=true if there is a nearestDatum', () => {
-    const wrapper = setup({
+    const { container } = setup({
       props: { showDatumGlyph: true },
       context: {
         tooltipOpen: true,
@@ -141,10 +149,11 @@ describe('<Tooltip />', () => {
         },
       ],
     });
-    expect(wrapper.find('div.visx-tooltip-glyph')).toHaveLength(1);
+    expect(container?.parentNode?.querySelectorAll('.visx-tooltip-glyph')).toHaveLength(1);
   });
+
   it('should render a glyph for each series if showSeriesGlyphs=true', () => {
-    const wrapper = setup({
+    const { container } = setup({
       props: { showSeriesGlyphs: true },
       context: {
         tooltipOpen: true,
@@ -170,6 +179,6 @@ describe('<Tooltip />', () => {
         },
       ],
     });
-    expect(wrapper.find('div.visx-tooltip-glyph')).toHaveLength(2);
+    expect(container?.parentNode?.querySelectorAll('div.visx-tooltip-glyph')).toHaveLength(2);
   });
 });

--- a/packages/visx-xychart/test/components/XYChart.test.tsx
+++ b/packages/visx-xychart/test/components/XYChart.test.tsx
@@ -1,13 +1,8 @@
 import React, { useContext } from 'react';
 import { mount } from 'enzyme';
-import ParentSize from '@visx/responsive/lib/components/ParentSize';
-import {
-  XYChart,
-  DataContext,
-  DataProvider,
-  EventEmitterProvider,
-  TooltipProvider,
-} from '../../src';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { XYChart, DataProvider, DataContext } from '../../src';
 
 const chartProps = {
   xScale: { type: 'linear' },
@@ -21,24 +16,18 @@ describe('<XYChart />', () => {
     expect(XYChart).toBeDefined();
   });
 
-  it('should render a ParentSize if width or height is not provided', () => {
-    const wrapper = mount(
-      <XYChart {...chartProps} width={undefined}>
-        <rect />
-      </XYChart>,
+  it('should render with parent size if width or height is not provided', () => {
+    const { getByTestId } = render(
+      <div style={{ width: '200px', height: '200px' }} data-testid="wrapper">
+        <XYChart {...chartProps} width={undefined} data-testid="rect">
+          <rect />
+        </XYChart>
+      </div>,
     );
-    expect(wrapper.find(ParentSize)).toHaveLength(1);
-  });
 
-  it('should render DataProvider, EventEmitterProvider, and TooltipProvider if not available in context', () => {
-    const wrapper = mount(
-      <XYChart {...chartProps}>
-        <rect />
-      </XYChart>,
-    );
-    expect(wrapper.find(DataProvider)).toHaveLength(1);
-    expect(wrapper.find(EventEmitterProvider)).toHaveLength(1);
-    expect(wrapper.find(TooltipProvider)).toHaveLength(1);
+    // the XYChart should auto-resize to it's parent size
+    const Wrapper = getByTestId('wrapper');
+    expect(Wrapper.firstChild).toHaveStyle('width: 100%; height: 100%');
   });
 
   it('should warn if DataProvider is not available and no x- or yScale config is passed', () => {
@@ -54,21 +43,23 @@ describe('<XYChart />', () => {
   });
 
   it('should render an svg', () => {
-    const wrapper = mount(
+    const { container } = render(
       <XYChart {...chartProps}>
         <rect />
       </XYChart>,
     );
-    expect(wrapper.find('svg')).toHaveLength(1);
+    const SVGElement = container.querySelector('svg');
+    expect(SVGElement).toBeDefined();
   });
 
   it('should render children', () => {
-    const wrapper = mount(
+    const { container } = render(
       <XYChart {...chartProps}>
         <rect id="xychart-child" />
       </XYChart>,
     );
-    expect(wrapper.find('#xychart-child')).toHaveLength(1);
+    const XYChartChild = container.querySelector('#xychart-child');
+    expect(XYChartChild).toBeDefined();
   });
 
   it('should update the registry dimensions', () => {
@@ -85,7 +76,7 @@ describe('<XYChart />', () => {
       return null;
     };
 
-    mount(
+    render(
       <DataProvider xScale={{ type: 'linear' }} yScale={{ type: 'linear' }}>
         <XYChart width={width} height={height}>
           <DataConsumer />

--- a/packages/visx-xychart/test/enhancers/withRegisteredData.test.tsx
+++ b/packages/visx-xychart/test/enhancers/withRegisteredData.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import withRegisteredData from '../../src/enhancers/withRegisteredData';
 import getDataContext from '../mocks/getDataContext';
 import { DataContext } from '../../src';
@@ -28,19 +29,19 @@ describe('withRegisteredData', () => {
     const BaseComponent = () => <div />;
     const WrappedComponent = withRegisteredData(BaseComponent);
 
-    const wrapperNoContext = mount(
+    const { container: containerNoContext } = render(
       <DataContext.Provider value={{}}>
         <WrappedComponent dataKey={series.key} {...series} />
       </DataContext.Provider>,
     );
-    const wrapperCompleteContext = mount(
+    const { container: containerCompleteContext } = render(
       <DataContext.Provider value={mockContextWithSeries}>
         <WrappedComponent dataKey={series.key} {...series} />
       </DataContext.Provider>,
     );
 
-    expect(wrapperNoContext.find('div')).toHaveLength(0);
-    expect(wrapperCompleteContext.find('div')).toHaveLength(1);
+    expect(containerNoContext.querySelectorAll('div')).toHaveLength(0);
+    expect(containerCompleteContext.querySelectorAll('div')).toHaveLength(1);
   });
 
   it('should pass data and accessors to BaseComponent from context not props', () => {
@@ -54,7 +55,7 @@ describe('withRegisteredData', () => {
     };
     const WrappedComponent = withRegisteredData(BaseComponent);
 
-    mount(
+    render(
       <DataContext.Provider value={mockContext}>
         <WrappedComponent
           dataKey={series.key}

--- a/packages/visx-xychart/test/hooks/useDataRegistry.test.tsx
+++ b/packages/visx-xychart/test/hooks/useDataRegistry.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import useDataRegistry from '../../src/hooks/useDataRegistry';
 
 describe('useDataRegistry', () => {
@@ -17,6 +17,6 @@ describe('useDataRegistry', () => {
       return null;
     };
 
-    mount(<RegistryConsumer />);
+    render(<RegistryConsumer />);
   });
 });

--- a/packages/visx-xychart/test/hooks/useEventEmitter.test.tsx
+++ b/packages/visx-xychart/test/hooks/useEventEmitter.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import useEventEmitter from '../../src/hooks/useEventEmitter';
 import { EventEmitterProvider } from '../../src';
 
@@ -21,7 +21,7 @@ describe('useEventEmitter', () => {
       return null;
     };
 
-    mount(
+    render(
       <EventEmitterProvider>
         <Component />
       </EventEmitterProvider>,
@@ -45,7 +45,7 @@ describe('useEventEmitter', () => {
       return null;
     };
 
-    mount(
+    render(
       <EventEmitterProvider>
         <Component />
       </EventEmitterProvider>,
@@ -78,7 +78,7 @@ describe('useEventEmitter', () => {
       return null;
     };
 
-    mount(
+    render(
       <EventEmitterProvider>
         <Component />
       </EventEmitterProvider>,

--- a/packages/visx-xychart/test/hooks/useEventEmitters.test.tsx
+++ b/packages/visx-xychart/test/hooks/useEventEmitters.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { EventEmitterProvider, useEventEmitter } from '../../src';
 import useEventEmitters from '../../src/hooks/useEventEmitters';
 
@@ -28,7 +28,7 @@ describe('useEventEmitters', () => {
       return null;
     };
 
-    mount(
+    render(
       <EventEmitterProvider>
         <Component />
       </EventEmitterProvider>,
@@ -53,7 +53,7 @@ describe('useEventEmitters', () => {
       return null;
     };
 
-    mount(
+    render(
       <EventEmitterProvider>
         <Component />
       </EventEmitterProvider>,

--- a/packages/visx-xychart/test/hooks/useEventHandlers.test.tsx
+++ b/packages/visx-xychart/test/hooks/useEventHandlers.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { EventEmitterProvider, useEventEmitter, DataContext } from '../../src';
 import useEventHandlers, { POINTER_EVENTS_ALL } from '../../src/hooks/useEventHandlers';
 import getDataContext from '../mocks/getDataContext';
@@ -12,7 +12,7 @@ const getEvent = (eventType: string) =>
 
 describe('useEventHandlers', () => {
   function setup(children: React.ReactNode) {
-    return mount(
+    return render(
       <DataContext.Provider value={getDataContext([series1, series2])}>
         <EventEmitterProvider>{children}</EventEmitterProvider>
       </DataContext.Provider>,

--- a/packages/visx-xychart/test/hooks/useStackedData.test.tsx
+++ b/packages/visx-xychart/test/hooks/useStackedData.test.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { AreaSeries, DataContext, DataProvider } from '../../src';
 import useStackedData from '../../src/hooks/useStackedData';
 
@@ -25,7 +25,7 @@ const seriesBProps = {
 };
 
 function setup(children: React.ReactElement | React.ReactElement[]) {
-  return mount(
+  return render(
     <DataProvider
       initialDimensions={{ width: 10, height: 10 }}
       xScale={{ type: 'band' }}

--- a/packages/visx-xychart/test/mocks/setupTooltipTest.tsx
+++ b/packages/visx-xychart/test/mocks/setupTooltipTest.tsx
@@ -1,6 +1,6 @@
 /* eslint import/no-extraneous-dependencies: 'off' */
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { DataProvider, EventEmitterProvider, TooltipContext, TooltipContextType } from '../../src';
 
 const providerProps = {
@@ -23,7 +23,7 @@ export default function setupTooltipTest(
   children: React.ReactNode,
   tooltipContext?: Partial<TooltipContextType<object>>,
 ) {
-  return mount(
+  return render(
     <DataProvider {...providerProps}>
       <EventEmitterProvider>
         <TooltipContext.Provider value={{ ...defaultTooltipContext, ...tooltipContext }}>

--- a/packages/visx-xychart/test/providers/DataProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/DataProvider.test.tsx
@@ -1,11 +1,11 @@
 import React, { useContext, useEffect } from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { DataProvider, DataContext } from '../../src';
 import { DataProviderProps } from '../../lib/providers/DataProvider';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getWrapper = (consumer: React.ReactNode, props?: DataProviderProps<any, any>) => {
-  mount(
+  render(
     <DataProvider xScale={{ type: 'linear' }} yScale={{ type: 'linear' }} {...props}>
       {consumer}
     </DataProvider>,

--- a/packages/visx-xychart/test/providers/EventEmitterProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/EventEmitterProvider.test.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { EventEmitterProvider, EventEmitterContext } from '../../src';
 
 describe('<EventEmitterProvider />', () => {
@@ -17,7 +17,7 @@ describe('<EventEmitterProvider />', () => {
       return null;
     };
 
-    mount(
+    render(
       <EventEmitterProvider>
         <EventEmitterConsumer />
       </EventEmitterProvider>,

--- a/packages/visx-xychart/test/providers/ThemeProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/ThemeProvider.test.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { ThemeProvider, ThemeContext } from '../../src';
 
 describe('<ThemeProvider />', () => {
@@ -17,7 +17,7 @@ describe('<ThemeProvider />', () => {
       return null;
     };
 
-    mount(
+    render(
       <ThemeProvider>
         <ThemeConsumer />
       </ThemeProvider>,

--- a/packages/visx-xychart/test/providers/TooltipProvider.test.tsx
+++ b/packages/visx-xychart/test/providers/TooltipProvider.test.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { TooltipProvider, TooltipContext, TooltipData } from '../../src';
 
 describe('<TooltipProvider />', () => {
@@ -22,7 +22,7 @@ describe('<TooltipProvider />', () => {
       return null;
     };
 
-    mount(
+    render(
       <TooltipProvider>
         <TooltipConsumer />
       </TooltipProvider>,
@@ -70,7 +70,7 @@ describe('<TooltipProvider />', () => {
       return null;
     };
 
-    mount(
+    render(
       <TooltipProvider>
         <TooltipConsumer />
       </TooltipProvider>,


### PR DESCRIPTION
# Overview
- upgrade visx-xychart to use react 17
- rewrite unit tests that use mount
- rewrite unit tests that uses `find(Component)` pattern in enzyme to testing-library:
   - testing-library avoids checking implementation details -> [reference issue](https://github.com/testing-library/react-testing-library/issues/251) 
